### PR TITLE
Update Gemfiles

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ember_devise_simple_auth (0.4.4)
+    ember_devise_simple_auth (0.5.0)
       devise (>= 3.0.0)
 
 GEM

--- a/examples/ember-rails/Gemfile.lock
+++ b/examples/ember-rails/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    ember_devise_simple_auth (0.4.4)
+    ember_devise_simple_auth (0.5.0)
       devise (>= 3.0.0)
 
 GEM

--- a/examples/ember-rails/Gemfile.lock
+++ b/examples/ember-rails/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
     sdoc (0.4.0)
       json (~> 1.8)
       rdoc (~> 4.0, < 5.0)
-    sprockets (2.11.1)
+    sprockets (2.12.0)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)


### PR DESCRIPTION
Hi,

I believe `ember_devise_simple_auth` versions have to be bumped to 0.5.0
Furthermore sprockets had to be updated as 2.11.1 was yanked.
