### PR TITLE
Add missing store to sign in process

### DIFF
--- a/app/models/authenticator.js
+++ b/app/models/authenticator.js
@@ -51,8 +51,8 @@ var Authenticator = Ember.Object.extend({
            });
 
   },
-  signIn: function() {
-    var setup = this.setupSession.bind(this),
+  signIn: function(store) {
+    var setup = this.setupSession.bind(this, store),
         data = {
           user: {
             email: this.get("email"),


### PR DESCRIPTION
Yes, this change is breaking, but actually not as this was not working before at all. The setupSession being called afterwards was failing on setting the user.

This fixes https://github.com/d-i/ember-devise-simple-auth/issues/32 when you add the store to your calls.
